### PR TITLE
Allow root-relative URLs for non-stylesheet resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Options:
 
 - **timeout** (Number): Specify how long to wait for the JS to be loaded.
 
-- **htmlroot** (String): Where the project root is. Useful for example if you are running UnCSS on _local_ files that have absolute href to the stylesheets, i.e. `href="/css/style.css"`.
+- **htmlroot** (String): Where the project root is. Useful for example if you have HTML that references _local_ files with root-relative URLs, i.e. `href="/css/style.css"`.
 
 - **report** (Boolean): Return the report object in callback.
 

--- a/src/jsdom.js
+++ b/src/jsdom.js
@@ -52,15 +52,12 @@ function fromSource(src, options) {
     // looked up relative to file://, so will not be found.
     if (options.htmlroot) {
         config.resourceLoader = function(resource, callback) {
-            var originalPathname = resource.url.pathname;
-            if (resource.url.protocol === 'file:') {
-                // All resource.url.pathames are absolute at this point, because jsdom
-                // has already prefixed relative paths with the baseUrl. So we have
-                // to identify which paths still need that prefix (the root-relative ones).
-                var baseDir = path.dirname(resource.baseUrl.replace(/^file:\/\//, ''));
-                if (!_.startsWith(originalPathname, baseDir)) {
-                    resource.url.pathname = path.join(options.htmlroot, originalPathname);
-                }
+            // Ensure htmlroot is an absolute path.
+            var htmlroot = path.resolve(options.htmlroot);
+
+            // Only apply htmlroot to local root-relative resources.
+            if (resource.url.protocol === 'file:' && resource.url.pathname.indexOf(htmlroot) !== 0) {
+                resource.url.pathname = path.join(options.htmlroot, resource.url.pathname);
             }
             return resource.defaultFetch(callback);
         };

--- a/src/jsdom.js
+++ b/src/jsdom.js
@@ -53,8 +53,14 @@ function fromSource(src, options) {
     if (options.htmlroot) {
         config.resourceLoader = function(resource, callback) {
             var originalPathname = resource.url.pathname;
-            if (/^\/[^/]/.test(originalPathname)) {
-                resource.url.pathname = path.join(options.htmlroot, originalPathname);
+            if (resource.url.protocol === 'file:') {
+                // All resource.url.pathames are absolute at this point, because jsdom
+                // has already prefixed relative paths with the baseUrl. So we have
+                // to identify which paths still need that prefix (the root-relative ones).
+                var baseDir = path.dirname(resource.baseUrl.replace(/^file:\/\//, ''));
+                if (!_.startsWith(originalPathname, baseDir)) {
+                    resource.url.pathname = path.join(options.htmlroot, originalPathname);
+                }
             }
             return resource.defaultFetch(callback);
         };

--- a/tests/jsdom.js
+++ b/tests/jsdom.js
@@ -58,4 +58,13 @@ describe('jsdom', function () {
             done();
         });
     });
+
+    it('Should not use htmlroot when loading non-root-relative scripts', function (done) {
+        var options = { htmlroot: path.join(__dirname, './jsdom') };
+        uncss(['tests/jsdom/non_root_relative_script.html'], options, function (err, output) {
+            expect(err).to.equal(null);
+            expect(output).to.include('.evaluated');
+            done();
+        });
+    });
 });

--- a/tests/jsdom.js
+++ b/tests/jsdom.js
@@ -67,4 +67,13 @@ describe('jsdom', function () {
             done();
         });
     });
+
+    it('Should not use htmlroot when loading non-root-relative scripts in a subfolder', function (done) {
+        var options = { htmlroot: path.join(__dirname, './jsdom') };
+        uncss(['tests/jsdom/sub/non_root_relative_script.html'], options, function (err, output) {
+            expect(err).to.equal(null);
+            expect(output).to.include('.evaluated');
+            done();
+        });
+    });
 });

--- a/tests/jsdom.js
+++ b/tests/jsdom.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var expect = require('chai').expect,
+    path = require('path'),
     uncss = require('./../src/uncss.js');
 
 describe('jsdom', function () {
@@ -36,6 +37,24 @@ describe('jsdom', function () {
         }, function (err, output) {
             expect(err).to.equal(null);
             expect(output).to.include('.timeout');
+            done();
+        });
+    });
+
+    it('Should use htmlroot to load root-relative scripts', function (done) {
+        var options = { htmlroot: path.join(__dirname, './jsdom') };
+        uncss(['tests/jsdom/root_relative_script.html'], options, function (err, output) {
+            expect(err).to.equal(null);
+            expect(output).to.include('.evaluated');
+            done();
+        });
+    });
+
+    it('Should use htmlroot to load root-relative scripts the same way if htmlroot ends with a slash', function (done) {
+        var options = { htmlroot: path.join(__dirname, './jsdom/') };
+        uncss(['tests/jsdom/root_relative_script.html'], options, function (err, output) {
+            expect(err).to.equal(null);
+            expect(output).to.include('.evaluated');
             done();
         });
     });

--- a/tests/jsdom/external_script.js
+++ b/tests/jsdom/external_script.js
@@ -1,0 +1,6 @@
+/* eslint-env browser */
+'use strict';
+
+var div = document.createElement('div');
+div.className = 'evaluated';
+document.body.appendChild(div);

--- a/tests/jsdom/non_root_relative_script.html
+++ b/tests/jsdom/non_root_relative_script.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <title>jsdom non-root-relative script test</title>
+        <link rel="stylesheet" href="jsdom.css">
+    </head>
+    <body>
+        <script src="external_script.js"></script>
+    </body>
+</html>

--- a/tests/jsdom/root_relative_script.html
+++ b/tests/jsdom/root_relative_script.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <title>jsdom root-relative script test</title>
+        <link rel="stylesheet" href="jsdom.css">
+    </head>
+    <body>
+        <script src="/external_script.js"></script>
+    </body>
+</html>

--- a/tests/jsdom/sub/non_root_relative_script.html
+++ b/tests/jsdom/sub/non_root_relative_script.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <title>jsdom non-root-relative script test</title>
+        <link rel="stylesheet" href="../jsdom.css">
+    </head>
+    <body>
+        <script src="../external_script.js"></script>
+    </body>
+</html>


### PR DESCRIPTION
I tried to address https://github.com/giakki/uncss/issues/287 by using jsdom's `resourceLoader` to amend root-relative URLs if the user has provided an `htmlroot`.

cc @vseventer @RyanZim